### PR TITLE
Fix og:metadata to enable Facebook graph scrape

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,11 @@
   <meta name="description" content="Welcome to Blueprint: MIT's high school hackathon!">
   <meta name=viewport content="width=device-width, initial-scale=1.0">
 
-  <meta property="og:url" content="https://blueprint.hackmit.org">
   <meta property="og:title" content="Blueprint 2016">
-  <meta property="og:description" content="Welcome to Blueprint: MIT's high school hackathon!">
+  <meta property="og:description" content="Welcome to Blueprint: MIT's high school hackathon! Learn from MIT students, make new friends, and build something cool. February 27 - 28.">
   <meta property="og:image" content="/assets/images/facebook.png">
+  <meta property="article:publisher" content="https://www.facebook.com/mitblueprint">
+  <meta property="og:site_name" content="Blueprint">
 
   <link href="/assets/images/favicon.png" rel="icon" type="image/png">
   <link href='https://fonts.googleapis.com/css?family=Rokkitt:400,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Having og:url causes a redirect to a secure version that the scraper is apparently not able to handle.
